### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A simple Model Context Protocol (MCP) server that provides timestamp-based UUIDs whenever it's called by an LLM.
 
+<a href="https://glama.ai/mcp/servers/@prazedotid/uuid-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@prazedotid/uuid-mcp/badge" alt="UUID Provider MCP server" />
+</a>
+
 ## Features
 
 - Provides a single tool: `generateUuid`


### PR DESCRIPTION
This PR adds a badge for the [UUID MCP Provider](https://glama.ai/mcp/servers/@prazedotid/uuid-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@prazedotid/uuid-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@prazedotid/uuid-mcp/badge" alt="UUID Provider MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.